### PR TITLE
ResultPage で votingEvent は AppRouteStatus のパスパラメータから ProviderScope 配下で固定のものを受け取るようにする

### DIFF
--- a/lib/features/voting_event/voting_event.dart
+++ b/lib/features/voting_event/voting_event.dart
@@ -1,16 +1,35 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tuple/tuple.dart';
 
 import '../../models/voting_event.dart';
 import '../../repositories/firestore/voting_event_repository.dart';
 import '../../utils/exceptions/base.dart';
 import '../auth/auth.dart';
 
-/// VotingEvent 一覧を購読する StreamProvider。
+/// 最新の VotingEvent 一覧を購読する StreamProvider。
 final latestVotingEventStreamProvider =
     StreamProvider.family.autoDispose<VotingEvent, String>((ref, roomId) {
   final userId = ref.watch(userIdProvider).value;
   if (userId == null) {
     throw const AppException(message: 'サインインが必要です。');
   }
-  return ref.read(votingEventRepositoryProvider).subscribeLatestVotingEvent(roomId: roomId);
+  return ref
+      .read(votingEventRepositoryProvider)
+      .subscribeLatestVotingEvent(roomId: roomId);
+});
+
+/// 指定した VotingEvent 一覧を購読する StreamProvider。
+/// スコープが狭いので Tuple を使用する
+final votingEventStreamProvider = StreamProvider.family
+    .autoDispose<VotingEvent?, Tuple2<String, String>>((ref, tuple) {
+  final userId = ref.watch(userIdProvider).value;
+  if (userId == null) {
+    throw const AppException(message: 'サインインが必要です。');
+  }
+
+  final result = ref
+      .read(votingEventRepositoryProvider)
+      .subscribeVotingEvent(roomId: tuple.item1, votingEventId: tuple.item2);
+
+  return result;
 });

--- a/lib/pages/result_page.dart
+++ b/lib/pages/result_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tuple/tuple.dart';
 
 import '../features/voting_event/voting_event.dart';
 import '../models/voting_event_status.dart';
@@ -24,6 +25,22 @@ final _roomIdProvider = Provider.autoDispose<String>(
   ],
 );
 
+/// roomId を取得してから返す Provider。
+final _votingEventIdProvider = Provider.autoDispose<String>(
+  (ref) {
+    try {
+      final state = ref.read(appRouterStateProvider);
+      final votingEventId = state.params['votingEventId']!;
+      return votingEventId;
+    } on Exception {
+      throw const AppException(message: '投票イベントのIDが見つかりませんでした。');
+    }
+  },
+  dependencies: <ProviderOrFamily>[
+    appRouterStateProvider,
+  ],
+);
+
 /// 投票結果ページ。
 /// 対象の VotingEvent.status が voting or finished のときに表示する想定。
 class ResultPage extends HookConsumerWidget {
@@ -39,10 +56,19 @@ class ResultPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final roomId = ref.watch(_roomIdProvider);
-    // TODO:  VotingEventRepository.subscribeVotingEvent() の方を使う StreamProvider を
-    //  このファイルに定義してしまって使用する。
-    return ref.watch(latestVotingEventStreamProvider(roomId)).when(
+    final votingEventId = ref.watch(_votingEventIdProvider);
+    return ref
+        .watch(votingEventStreamProvider(Tuple2(roomId, votingEventId)))
+        .when(
           data: (votingEvent) {
+            if (votingEvent == null) {
+              return Scaffold(
+                appBar: AppBar(title: const Text('エラー')),
+                body: const EmptyPlaceholderWidget(
+                  message: '有効な投票イベントが存在しません',
+                ),
+              );
+            }
             switch (votingEvent.status) {
               case VotingEventStatus.voting:
                 return const VotingWidget();
@@ -85,7 +111,6 @@ class VotingWidget extends HookConsumerWidget {
         title: Column(
           children: const [
             Text('投票中'),
-            Text('投票中です。'),
           ],
         ),
       ),
@@ -110,7 +135,8 @@ class FinishedWidget extends HookConsumerWidget {
           children: [
             const Text('投票終了'),
             ElevatedButton(
-              onPressed: () => Navigator.popUntil(context, (route) => route.isFirst),
+              onPressed: () =>
+                  Navigator.popUntil(context, (route) => route.isFirst),
               child: const Text('戻る'),
             )
           ],

--- a/lib/pages/result_page.dart
+++ b/lib/pages/result_page.dart
@@ -25,7 +25,7 @@ final _roomIdProvider = Provider.autoDispose<String>(
   ],
 );
 
-/// roomId を取得してから返す Provider。
+/// votingEventId を取得してから返す Provider。
 final _votingEventIdProvider = Provider.autoDispose<String>(
   (ref) {
     try {

--- a/lib/repositories/firestore/voting_event_repository.dart
+++ b/lib/repositories/firestore/voting_event_repository.dart
@@ -18,6 +18,7 @@ class VotingEventRepository {
   }
 
   /// 指定した VotingEvent を購読する。
+  /// 投票結果画面の切り替えに使用している
   Stream<VotingEvent?> subscribeVotingEvent({
     required String roomId,
     required String votingEventId,
@@ -25,6 +26,7 @@ class VotingEventRepository {
     final streamDocumentSnapshot =
         votingEventRef(roomId: roomId, votingEventId: votingEventId).snapshots();
     final result = streamDocumentSnapshot.map((ds) => ds.data());
+
     return result;
   }
 }


### PR DESCRIPTION
# ResultPage で votingEvent は AppRouteStatus のパスパラメータから ProviderScope 配下で固定のものを受け取るようにする

途中でFirestore のフィールドを変更している。

## キャプチャ

https://user-images.githubusercontent.com/75112184/185759151-7fc26095-7b9d-40e2-b2d5-c2803f1ae55f.mp4


